### PR TITLE
Loosen versions for required deps and test with latest

### DIFF
--- a/dockerfiles/test.Dockerfile
+++ b/dockerfiles/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.3.2
+FROM python:3.9.5-slim-buster
 
 WORKDIR /app
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
-requests==2.24.0
-flake8==3.8.4
-scikit-learn==0.23.2
-torch==1.7.0
-transformers==4.3.0
-tensorflow==2.3.2
-sentencepiece==0.1.95
+requests==2.25.1
+flake8==3.9.2
+scikit-learn==0.24.2
+torch==1.9.0
+transformers==4.8.1
+tensorflow==2.5.0
+sentencepiece==0.1.96

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 from setuptools.command.install import install
 
 # The version of this package
-VERSION = "0.1.9"
+VERSION = "0.1.10"
 
 
 class VerifyVersionCommand(install):
@@ -45,11 +45,11 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "fastapi==0.63.0",
-        "pydantic==1.7.3",
-        "google-cloud-storage==1.35.1",
-        "google-cloud-pubsub==2.2.0",
-        "google-cloud-error-reporting==1.1.1",
+        "fastapi>=0.63.0",
+        "pydantic>=1.7.3",
+        "google-cloud-storage>=1.35.1",
+        "google-cloud-pubsub>=2.2.0",
+        "google-cloud-error-reporting>=1.1.1",
         "numpy>=1.15.4",
         "scikit-learn>=0.20.3",
         "requests>=2.21.0",

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import typing as t
+from abc import ABC, abstractmethod
 
 from pydantic import BaseModel
 
@@ -11,7 +12,13 @@ def load_json_file(path):
         return json.load(f)
 
 
-class FileSpec(BaseModel):
+class FileSystemObjectSpec(ABC):
+    @abstractmethod
+    def write(self, parent: str = ""):
+        pass
+
+
+class FileSpec(BaseModel, FileSystemObjectSpec):
     path: str  # should be relative to parent, unless there is no parent
     content: str
 
@@ -30,20 +37,20 @@ class FileSpec(BaseModel):
         return cls(path=path, content=content)
 
 
-class DirSpec(BaseModel):
+class DirSpec(BaseModel, FileSystemObjectSpec):
     """Recursively write this directory and all of its children.
     """
     path: str  # should be relative to parent, unless there is no parent
-    children: t.List[t.Union[FileSpec, "DirSpec"]]
+    children: t.List[FileSystemObjectSpec]
+
+    class Config:
+        arbitrary_types_allowed = True
 
     def write(self, parent: str = ""):
         full_path = os.path.join(parent, self.path)
         os.makedirs(full_path)
         for child in self.children:
-            if isinstance(child, DirSpec):
-                child.write(full_path)
-            elif isinstance(child, FileSpec):
-                child.write(full_path)
+            child.write(full_path)
 
     def remove(self, parent: str = ""):
         shutil.rmtree(os.path.join(parent, self.path))


### PR DESCRIPTION
Loosens the required dependency versions of this package, freeing downstream services that use this package from having to use those exact versions. Downstream services can pin dependencies to specific versions that they test with, but this package just tests against the latest versions.