### PR TITLE
Allow more custom serialization when persisting data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bavard-ml-utils"
-version = "0.2.2"
+version = "0.2.3"
 description = "Utilities for machine learning, python web services, and cloud infrastructure"
 license = "MIT"
 authors = ["Bavard AI, Inc. <dev@bavard.ai>"]


### PR DESCRIPTION
This PR makes Pydantic model serialization behavior more customize-able. It also now by default doesn't convert `datetime` objects into strings, since Firestore uses them to know when a field is a timestamp, and not just a regular string or float. That behavior can be overridden by the user if desired.