### PR TITLE
Fix decimal rounding

### DIFF
--- a/bavard_ml_utils/persistence/record_store/dynamodb.py
+++ b/bavard_ml_utils/persistence/record_store/dynamodb.py
@@ -42,7 +42,7 @@ class DynamoDBRecordStore(BaseRecordStore[RecordT]):
             "dynamodb", endpoint_url=os.getenv("AWS_ENDPOINT"), config=Config(region_name=os.getenv("AWS_REGION"))
         ).Table(table_name)
         self._pk = primary_key_field_name
-        self._decimal_ctx = Context()
+        self._decimal_ctx = Context(prec=38)  # dynamodb has a maximum precision of 38 digits for decimal numbers
 
     def save(self, record: RecordT):
         self.assert_can_edit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bavard-ml-utils"
-version = "0.2.8"
+version = "0.2.9"
 description = "Utilities for machine learning, python web services, and cloud infrastructure"
 license = "MIT"
 authors = ["Bavard AI, Inc. <dev@bavard.ai>"]

--- a/test/persistence/test_record_store.py
+++ b/test/persistence/test_record_store.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime, timedelta, timezone
 from unittest import TestCase
 
@@ -40,7 +41,7 @@ class TestRecordStore(TestCase):
             DynamoDBRecordStore("fruits", Fruit),
         ]
         self.apple = Fruit(name="apple", color="red", is_tropical=False, price=0.5)
-        self.mango = Fruit(name="mango", color="yellow", is_tropical=True, price=1)
+        self.mango = Fruit(name="mango", color="yellow", is_tropical=True, price=math.pi)
         self.pear = Fruit(name="pear", color="green", is_tropical=False, price=0.75)
 
     def tearDown(self) -> None:


### PR DESCRIPTION
DynamoDB only supports decimal numbers with up to 38 significant digits. If you have a number with more than that (Python `float`s often do), then DynamoDB throws an Inexact/Rounding error. The rounding is unavoidable though. So here, we bypass the error being thrown by building `Decimal` objects using our own `decimal.Context` object.